### PR TITLE
Add '01' check for BoldOn

### DIFF
--- a/src/main/java/net/rubygrapefruit/ansi/AnsiParser.java
+++ b/src/main/java/net/rubygrapefruit/ansi/AnsiParser.java
@@ -141,7 +141,7 @@ public class AnsiParser {
             visitor.visit(BoldOff.INSTANCE);
             return true;
         }
-        if (params.equals("1")) {
+        if (params.equals("01") || params.equals("1")) {
             visitor.visit(BoldOn.INSTANCE);
             return true;
         }


### PR DESCRIPTION
Was working on an Android app which was reading some output from a shell command and displaying it in a view. Some of the output was color coded, so was using this project to parse the output correctly. Found out that the bold-on sequence was not correctly parsed so, made this small change to correctly parse it.