### PR TITLE
fix: Support '[xG' ansi sequences

### DIFF
--- a/src/main/java/net/rubygrapefruit/ansi/AnsiParser.java
+++ b/src/main/java/net/rubygrapefruit/ansi/AnsiParser.java
@@ -96,6 +96,14 @@ public class AnsiParser {
                 return true;
             }
         }
+        if (code == 'G') {
+            if (params.isEmpty() || params.equals("1")) {
+                visitor.visit(new CursorToColumn(1));
+            } else {
+                visitor.visit(new CursorToColumn(Integer.parseInt(params)));
+            }
+            return true;
+        }
         if (code == 'm') {
             if (params.isEmpty()) {
                 visitor.visit(ForegroundColor.DEFAULT);

--- a/src/main/java/net/rubygrapefruit/ansi/console/AnsiConsole.java
+++ b/src/main/java/net/rubygrapefruit/ansi/console/AnsiConsole.java
@@ -60,6 +60,8 @@ public class AnsiConsole implements Visitor {
             rows.get(row).eraseToStart(col);
         } else if (token instanceof EraseToEndOfLine) {
             rows.get(row).eraseToEnd(col);
+        } else if (token instanceof CursorToColumn) {
+            col = ((CursorToColumn) token).getCount();
         } else if (token instanceof BoldOn) {
             attributes = attributes.boldOn();
         } else if (token instanceof BoldOff) {

--- a/src/main/java/net/rubygrapefruit/ansi/token/CursorToColumn.java
+++ b/src/main/java/net/rubygrapefruit/ansi/token/CursorToColumn.java
@@ -1,0 +1,18 @@
+package net.rubygrapefruit.ansi.token;
+
+public class CursorToColumn extends ControlSequence {
+    private final int count;
+
+    public CursorToColumn(int count) {
+        this.count = count;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public void appendDiagnostic(StringBuilder builder) {
+        builder.append("{cursor-to-col ").append(count).append("}");
+    }
+}

--- a/src/test/groovy/net/rubygrapefruit/ansi/AnsiParserTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/ansi/AnsiParserTest.groovy
@@ -98,9 +98,12 @@ class AnsiParserTest extends Specification {
         output.write(bytes("\u001B[33C"))
         output.write(bytes("\u001B[D"))
         output.write(bytes("\u001B[20D"))
+        output.write(bytes("\u001B[G"))
+        output.write(bytes("\u001B[1G"))
+        output.write(bytes("\u001B[20G"))
 
         then:
-        visitor.tokens.size() == 9
+        visitor.tokens.size() == 12
         visitor.tokens[0] instanceof CursorUp
         visitor.tokens[0].count == 1
         visitor.tokens[1] instanceof CursorUp
@@ -119,6 +122,12 @@ class AnsiParserTest extends Specification {
         visitor.tokens[7].count == 1
         visitor.tokens[8] instanceof CursorBackward
         visitor.tokens[8].count == 20
+        visitor.tokens[9] instanceof CursorToColumn
+        visitor.tokens[9].count == 1
+        visitor.tokens[10] instanceof CursorToColumn
+        visitor.tokens[10].count == 1
+        visitor.tokens[11] instanceof CursorToColumn
+        visitor.tokens[11].count == 20
     }
 
     def "parses line clear control sequence"() {

--- a/src/test/groovy/net/rubygrapefruit/ansi/console/AnsiConsoleTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/ansi/console/AnsiConsoleTest.groovy
@@ -265,6 +265,34 @@ class AnsiConsoleTest extends Specification {
         console.contents(new DiagnosticConsole()).toString() == "some text\n...__\n1___"
     }
 
+    def "can move cursor to column"() {
+        given:
+        console.visit(new Text("some text"))
+        console.visit(NewLine.INSTANCE)
+        console.visit(NewLine.INSTANCE)
+        console.visit(new Text("123"))
+
+        expect:
+        console.visit(new CursorToColumn(1))
+        console.visit(new Text("___"))
+        console.rows[2].visit(new DiagnosticConsole()).toString() == "1___"
+        console.contents(new DiagnosticConsole()).toString() == "some text\n\n1___"
+
+        // Position cursor beyond end of line
+        console.visit(new CursorToColumn(5))
+        console.visit(new Text("+++"))
+        console.rows[2].visit(new DiagnosticConsole()).toString() == "1___ +++"
+        console.contents(new DiagnosticConsole()).toString() == "some text\n\n1___ +++"
+
+        // Move beyond end of next row and back
+        console.visit(NewLine.INSTANCE)
+        console.visit(new CursorToColumn(10))
+        console.visit(new CursorUp(3))
+        console.visit(new Text("---"))
+        console.rows[0].visit(new DiagnosticConsole()).toString() == "some text ---"
+        console.contents(new DiagnosticConsole()).toString() == "some text ---\n\n1___ +++\n"
+    }
+
     def "can erase in line"() {
         expect:
         console.visit(EraseInLine.INSTANCE)

--- a/src/test/groovy/net/rubygrapefruit/ansi/console/DiagnosticConsoleTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/ansi/console/DiagnosticConsoleTest.groovy
@@ -8,6 +8,7 @@ import net.rubygrapefruit.ansi.token.CarriageReturn
 import net.rubygrapefruit.ansi.token.CursorBackward
 import net.rubygrapefruit.ansi.token.CursorDown
 import net.rubygrapefruit.ansi.token.CursorForward
+import net.rubygrapefruit.ansi.token.CursorToColumn
 import net.rubygrapefruit.ansi.token.CursorUp
 import net.rubygrapefruit.ansi.token.EraseInLine
 import net.rubygrapefruit.ansi.token.EraseToBeginningOfLine
@@ -44,12 +45,13 @@ class DiagnosticConsoleTest extends Specification {
         console.visit(new CursorDown(12))
         console.visit(new CursorForward(1))
         console.visit(new CursorBackward(1))
-        console.toString() == "abc{escape 1;2m}\n{escape A}\n{cursor-up 4}{cursor-down 12}{cursor-forward 1}{cursor-backward 1}"
+        console.visit(new CursorToColumn(1))
+        console.toString() == "abc{escape 1;2m}\n{escape A}\n{cursor-up 4}{cursor-down 12}{cursor-forward 1}{cursor-backward 1}{cursor-to-col 1}"
 
         console.visit(EraseInLine.INSTANCE)
         console.visit(EraseToBeginningOfLine.INSTANCE)
         console.visit(EraseToEndOfLine.INSTANCE)
-        console.toString() == "abc{escape 1;2m}\n{escape A}\n{cursor-up 4}{cursor-down 12}{cursor-forward 1}{cursor-backward 1}{erase-in-line}{erase-to-beginning-of-line}{erase-to-end-of-line}"
+        console.toString() == "abc{escape 1;2m}\n{escape A}\n{cursor-up 4}{cursor-down 12}{cursor-forward 1}{cursor-backward 1}{cursor-to-col 1}{erase-in-line}{erase-to-beginning-of-line}{erase-to-end-of-line}"
 
         console.contents(new DiagnosticConsole()).toString() == console.toString()
     }


### PR DESCRIPTION
The `[xG` sequences, or "Cursor Horizontal Absolute" (also known as [CHA](https://en.wikipedia.org/wiki/ANSI_escape_code#CHA)), are not supported by the library yet. There are some tools, such as `npm`, that use these sequences to present interactive output. 

This PR adds support for those sequences.

The tests all pass locally for me:

<img width="853" alt="Screenshot 2024-11-13 at 4 27 45 PM" src="https://github.com/user-attachments/assets/cceef93a-33c9-4871-8bfa-b68c0d72861a">

