### PR TITLE
Add support for `Synchronized Output` control sequences

### DIFF
--- a/src/main/java/net/rubygrapefruit/ansi/AnsiParser.java
+++ b/src/main/java/net/rubygrapefruit/ansi/AnsiParser.java
@@ -139,6 +139,18 @@ public class AnsiParser {
                 return true;
             }
         }
+        if (code == 'h') {
+            if ("?2026".equals(params)) {
+                visitor.visit(BeginSynchronizedUpdate.INSTANCE);
+                return true;
+            }
+        }
+        if (code == 'l') {
+            if ("?2026".equals(params)) {
+                visitor.visit(EndSynchronizedUpdate.INSTANCE);
+                return true;
+            }
+        }
         return false;
     }
 
@@ -361,7 +373,7 @@ public class AnsiParser {
                         break;
                     case Param:
                         byte nextDigit = buffer.peek();
-                        if ((nextDigit < '0' || nextDigit > '9') && nextDigit != ';') {
+                        if ((nextDigit < '0' || nextDigit > '9') && nextDigit != ';' && nextDigit != '?') {
                             state = State.Code;
                         } else {
                             currentSequence.append((char) nextDigit);

--- a/src/main/java/net/rubygrapefruit/ansi/token/BeginSynchronizedUpdate.java
+++ b/src/main/java/net/rubygrapefruit/ansi/token/BeginSynchronizedUpdate.java
@@ -1,0 +1,13 @@
+package net.rubygrapefruit.ansi.token;
+
+public class BeginSynchronizedUpdate extends ControlSequence {
+    public static final BeginSynchronizedUpdate INSTANCE = new BeginSynchronizedUpdate();
+
+    private BeginSynchronizedUpdate() {
+    }
+
+    @Override
+    public void appendDiagnostic(StringBuilder builder) {
+        builder.append("{begin-synchronized-update}");
+    }
+}

--- a/src/main/java/net/rubygrapefruit/ansi/token/EndSynchronizedUpdate.java
+++ b/src/main/java/net/rubygrapefruit/ansi/token/EndSynchronizedUpdate.java
@@ -1,0 +1,13 @@
+package net.rubygrapefruit.ansi.token;
+
+public class EndSynchronizedUpdate extends ControlSequence {
+    public static final EndSynchronizedUpdate INSTANCE = new EndSynchronizedUpdate();
+
+    private EndSynchronizedUpdate() {
+    }
+
+    @Override
+    public void appendDiagnostic(StringBuilder builder) {
+        builder.append("{end-synchronized-update}");
+    }
+}

--- a/src/test/groovy/net/rubygrapefruit/ansi/console/DiagnosticConsoleTest.groovy
+++ b/src/test/groovy/net/rubygrapefruit/ansi/console/DiagnosticConsoleTest.groovy
@@ -2,6 +2,7 @@ package net.rubygrapefruit.ansi.console
 
 import net.rubygrapefruit.ansi.TextColor
 import net.rubygrapefruit.ansi.token.BackgroundColor
+import net.rubygrapefruit.ansi.token.BeginSynchronizedUpdate
 import net.rubygrapefruit.ansi.token.BoldOff
 import net.rubygrapefruit.ansi.token.BoldOn
 import net.rubygrapefruit.ansi.token.CarriageReturn
@@ -10,6 +11,7 @@ import net.rubygrapefruit.ansi.token.CursorDown
 import net.rubygrapefruit.ansi.token.CursorForward
 import net.rubygrapefruit.ansi.token.CursorToColumn
 import net.rubygrapefruit.ansi.token.CursorUp
+import net.rubygrapefruit.ansi.token.EndSynchronizedUpdate
 import net.rubygrapefruit.ansi.token.EraseInLine
 import net.rubygrapefruit.ansi.token.EraseToBeginningOfLine
 import net.rubygrapefruit.ansi.token.EraseToEndOfLine
@@ -74,6 +76,19 @@ class DiagnosticConsoleTest extends Specification {
 
         console.visit(BoldOff.INSTANCE)
         console.toString() == "{foreground-color bright green}{background-color blue}123{bold-on}{bold-off}"
+
+        console.contents(new DiagnosticConsole()).toString() == console.toString()
+    }
+
+    def "formats private tokens"() {
+        def console = new DiagnosticConsole()
+
+        expect:
+        console.visit(BeginSynchronizedUpdate.INSTANCE)
+        console.toString() == "{begin-synchronized-update}"
+
+        console.visit(EndSynchronizedUpdate.INSTANCE)
+        console.toString() == "{begin-synchronized-update}{end-synchronized-update}"
 
         console.contents(new DiagnosticConsole()).toString() == console.toString()
     }


### PR DESCRIPTION
This PR adds support for [Synchronized Output](https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md) control sequences. Recent versions of the Jest testing framework (one of the most widely used frameworks in the JavaScript ecosystem) have begun emitting these sequences (see https://github.com/jestjs/jest/pull/15008). Without this support, output may include raw control tokens instead of being handled correctly.