### PR TITLE
Use in memory pgp keys for signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,8 @@ publishing {
 }
 
 signing {
-    useGpgCmd()
     sign publishing.publications.maven
+    useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"))
 }
 
 //
@@ -175,7 +175,7 @@ incrementVersion.mustRunAfter(publish)
 //
 // See upload task above for setup instructions
 //
-// Run with -Psigning.gnupg.keyName=
+// Requires setting `$PGP_SIGNING_KEY` and `$PGP_SIGNING_KEY_PASSPHRASE`
 //
 // After running this task:
 // - promote on Maven central, see https://central.sonatype.com/publishing


### PR DESCRIPTION
Use in-memory PGP keys for signing as in other libraries, see https://github.com/gradle/develocity-testing-annotations/blob/8addb7bf82fadbdedb3b6b50fc0c68d8af21aec7/build.gradle.kts#L60.